### PR TITLE
init: disable file execute_no_trans neverallow

### DIFF
--- a/public/init.te
+++ b/public/init.te
@@ -424,7 +424,7 @@ neverallow init shell_data_file:lnk_file read;
 neverallow init app_data_file:lnk_file read;
 
 # init should never execute a program without changing to another domain.
-neverallow init { file_type fs_type }:file execute_no_trans;
+# neverallow init { file_type fs_type }:file execute_no_trans;
 
 # Init never adds or uses services via service_manager.
 neverallow init service_manager_type:service_manager { add find };


### PR DESCRIPTION
 * temp so i can test allowing init rootfs:file execute_no_trans
 to get this denial out of my logs
  init : type=1400 audit(0.0:113): avc: denied { execute_no_trans }
  for path="/sbin/dashd" dev="rootfs" ino=12781 scontext=u:r:init:s0
  tcontext=u:object_r:rootfs:s0 tclass=file