### PR TITLE
Add rules required for TARGET_HAS_LEGACY_CAMERA_HAL1. Legacy devices need this

### DIFF
--- a/definitions.mk
+++ b/definitions.mk
@@ -10,6 +10,7 @@ $(hide) m4 $(PRIVATE_ADDITIONAL_M4DEFS) \
 	-D target_with_asan=$(PRIVATE_TGT_WITH_ASAN) \
 	-D target_full_treble=$(PRIVATE_SEPOLICY_SPLIT) \
 	-D target_compatible_property=$(PRIVATE_COMPATIBLE_PROPERTY) \
+	-D target_has_legacy_camera_hal1=$(TARGET_HAS_LEGACY_CAMERA_HAL1) \
 	-D target_needs_platform_text_relocations=$(TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS) \
 	$(PRIVATE_TGT_RECOVERY) \
 	-s $^ > $@

--- a/public/cameraserver.te
+++ b/public/cameraserver.te
@@ -16,7 +16,12 @@ allow cameraserver ion_device:chr_file rw_file_perms;
 # Talk with graphics composer fences
 allow cameraserver hal_graphics_composer:fd use;
 
-add_service(cameraserver, cameraserver_service)
+ifelse(target_has_legacy_camera_hal1, `true',
+  allow cameraserver cameraserver_service:service_manager { add find };
+  neverallow { domain -cameraserver -mediaserver } cameraserver_service:service_manager add;
+,
+  add_service(cameraserver, cameraserver_service)
+)
 
 allow cameraserver activity_service:service_manager find;
 allow cameraserver appops_service:service_manager find;

--- a/public/mediaserver.te
+++ b/public/mediaserver.te
@@ -72,7 +72,12 @@ unix_socket_connect(mediaserver, drmserver, drmserver)
 # but seems appropriate for all devices.
 unix_socket_connect(mediaserver, bluetooth, bluetooth)
 
-add_service(mediaserver, mediaserver_service)
+ifelse(target_has_legacy_camera_hal1, `true',
+  allow mediaserver mediaserver_service:service_manager { add find };
+  neverallow { domain -mediaserver -cameraserver } mediaserver_service:service_manager add;
+,
+  add_service(mediaserver, mediaserver_service)
+)
 allow mediaserver activity_service:service_manager find;
 allow mediaserver appops_service:service_manager find;
 allow mediaserver audioserver_service:service_manager find;
@@ -94,6 +99,13 @@ allow mediaserver mediadrmserver_service:service_manager find;
 
 # For interfacing with OMX HAL
 allow mediaserver hidl_token_hwservice:hwservice_manager find;
+
+ifelse(target_has_legacy_camera_hal1, `true',
+  allow mediaserver cameraproxy_service:service_manager find;
+  allow mediaserver cameraserver_service:service_manager add;
+  allow mediaserver hal_camera_hwservice:hwservice_manager find;
+,
+)
 
 # /oem access
 allow mediaserver oemfs:dir search;


### PR DESCRIPTION
Author: Adrian DC <radian.dc@gmail.com>
Date:   Tue Oct 17 23:39:27 2017 +0200

    mediaserver: Allow finding the hal_camera hardware service

     * denied { find } for
        interface=android.hardware.camera.provider::ICameraProvider
        scontext=u:r:mediaserver:s0
        tcontext=u:object_r:hal_camera_hwservice:s0 tclass=hwservice_manager

    Change-Id: I5f61a5879f74ea4f1e29246784af512fea8f8127

Author: Adrian DC <radian.dc@gmail.com>
Date:   Mon Aug 14 01:21:06 2017 +0200

    Adapt add_service uses for TARGET_HAS_LEGACY_CAMERA_HAL1

     * Avoid mutual neverallow between mediaserver and cameraserver

    Change-Id: I1f58f1144796601c85b743ce2cdcb97034b5301e
    Signed-off-by: Adrian DC <radian.dc@gmail.com>

Change-Id: Ica4926fa3acf88b95c687f25eec4dbc68ea41fbb